### PR TITLE
Remove email confirmation for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :confirmable, :omniauthable
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   has_many :bookings, dependent: :destroy
   has_many :listings, dependent: :destroy


### PR DESCRIPTION
We don't need this, especially when we're using fake emails for certain things.
